### PR TITLE
Add error handling for LAN search results

### DIFF
--- a/example.py
+++ b/example.py
@@ -26,6 +26,7 @@ from ctypes import (
     POINTER,
 )
 from pathlib import Path
+import logging
 import sys
 
 # ---------------------------------------------------------------------------
@@ -86,6 +87,9 @@ def discover_printers(timeout_ms: int = 2000, max_num: int = 16):
 
     devices = (IOTCDevInfo * max_num)()
     count = IOTC.IOTC_Lan_Search2(byref(devices[0]), c_int(max_num), c_uint(timeout_ms))
+    if count < 0:
+        logging.error("IOTC_Lan_Search2 failed with code %d", count)
+        return []
     return [
         (
             devices[i].UID.decode(errors="ignore").rstrip("\x00"),


### PR DESCRIPTION
## Summary
- log and return empty list if `IOTC_Lan_Search2` returns a negative count in `discover_printers`
- import `logging` for error reporting

## Testing
- `python -m py_compile example.py`


------
https://chatgpt.com/codex/tasks/task_e_6894f7303cac8329b26e191e8535ddd6